### PR TITLE
mocks

### DIFF
--- a/tests/resources/mock.ipynb
+++ b/tests/resources/mock.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbmake": {
+     "mock": {
+      "x": 2,
+      "y": "fish",
+      "z": {
+       "x": 42
+      }
+     }
+    }
+   },
+   "outputs": [],
+   "source": [
+    "x = 5\n",
+    "y = 'y'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert x == 2\n",
+    "assert y == \"fish\"\n",
+    "assert z == { \"x\": 42 }"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_nb_run.py
+++ b/tests/test_nb_run.py
@@ -113,3 +113,9 @@ class TestNotebookRun:
         run = NotebookRun(nb, 300)
         res: NotebookResult = run.execute()
         assert res.error == None
+
+    def test_when_mock_then_succeeds(self, testdir2: Testdir):
+        nb = Path(__file__).parent / "resources" / "mock.ipynb"
+        run = NotebookRun(nb, 300)
+        res: NotebookResult = run.execute()
+        assert res.error == None


### PR DESCRIPTION
Enable mocking variables by allowing metadata which causes nbmake to overwrite variables after a cell finishes.

issue: https://github.com/treebeardtech/nbmake/issues/72

example from unit test:
```json
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {
    "nbmake": {
     "mock": {
      "x": 2,
      "y": "fish",
      "z": {
       "x": 42
      }
     }
    }
   },
   "outputs": [],
   "source": [
    "x = 5\n",
    "y = 'y'"
   ]
  },
```
