### PR TITLE
add --nbmake-find-import-errors

### DIFF
--- a/src/nbmake/pytest_items.py
+++ b/src/nbmake/pytest_items.py
@@ -47,6 +47,7 @@ class NotebookItem(pytest.Item):
             option.nbmake_timeout,
             verbose=bool(option.verbose),
             kernel=option.nbmake_kernel,
+            find_import_errors=option.nbmake_find_import_errors,
         )
 
         res: NotebookResult = run.execute()

--- a/src/nbmake/pytest_plugin.py
+++ b/src/nbmake/pytest_plugin.py
@@ -42,6 +42,13 @@ def pytest_addoption(parser: Any):
         type=str,
     )
 
+    group.addoption(
+        "--nbmake-find-import-errors",
+        action="store_true",
+        help="Runs all cells, only reports import errors",
+        default=False,
+    )
+
 
 def pytest_collect_file(path: str, parent: Any) -> Optional[Any]:
     opt = parent.config.option

--- a/tests/resources/import_errs.ipynb
+++ b/tests/resources/import_errs.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "1/0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "time.sleep(600)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import lkjlkj"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.8 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "949777d72b0d2535278d3dc13498b2535136f6dfe0678499012e853ee9abcab1"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_nb_run.py
+++ b/tests/test_nb_run.py
@@ -133,3 +133,10 @@ class TestNotebookRun:
         run = NotebookRun(nb, 300)
         res: NotebookResult = run.execute()
         assert res.error is None
+
+    def test_when_import_error_then_fails(self, testdir2: Never):
+        nb = Path(__file__).parent / "resources" / "import_errs.ipynb"
+        run = NotebookRun(nb, 1, find_import_errors=True)
+        res: NotebookResult = run.execute()
+        assert res.error is not None
+        assert "ModuleNotFoundError" in res.error.summary

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -184,3 +184,14 @@ def test_when_kernel_passed_then_override(pytester: Pytester, testdir2: Never):
     hook_recorder = pytester.inline_run("--nbmake", "--nbmake-kernel=python3")
 
     assert hook_recorder.ret == ExitCode.OK
+
+
+def test_when_no_import_errs_then_pass(pytester: Pytester, testdir2: Never):
+    write_nb(
+        ["import itertools", "1/0", "import pickle"],
+        Path(pytester.path) / "a.ipynb",
+    )
+
+    hook_recorder = pytester.inline_run("--nbmake", "--nbmake-find-import-errors")
+
+    assert hook_recorder.ret == ExitCode.OK


### PR DESCRIPTION
Runs cells ignoring timeouts and errors other than `ModuleNotFoundError`s

https://github.com/treebeardtech/nbmake/issues/86