### PR TITLE
Add notebook markers

### DIFF
--- a/src/nbmake/pytest_items.py
+++ b/src/nbmake/pytest_items.py
@@ -11,7 +11,7 @@ from pygments.formatters import TerminalTrueColorFormatter
 from pygments.lexers import Python3TracebackLexer
 
 from .nb_result import NotebookError, NotebookResult
-from .nb_run import NotebookRun
+from .nb_run import NB_VERSION, NotebookRun
 
 
 class NbMakeFailureRepr(TerminalRepr):
@@ -27,7 +27,8 @@ class NotebookFile(pytest.File):
     def collect(self) -> Generator[Any, Any, Any]:
         item = NotebookItem.from_parent(self, filename=str(Path(self.fspath)))
 
-        nb = nbformat.read(self.fspath, 4)
+        with open(self.fspath, "rb") as fp:
+            nb = nbformat.read(fp, NB_VERSION)
 
         try:
             markers = nb.metadata.execution.markers

--- a/src/nbmake/pytest_items.py
+++ b/src/nbmake/pytest_items.py
@@ -25,7 +25,22 @@ class NbMakeFailureRepr(TerminalRepr):
 
 class NotebookFile(pytest.File):
     def collect(self) -> Generator[Any, Any, Any]:
-        yield NotebookItem.from_parent(self, filename=str(Path(self.fspath)))
+        item = NotebookItem.from_parent(self, filename=str(Path(self.fspath)))
+
+        nb = nbformat.read(self.fspath, 4)
+
+        try:
+            markers = nb.metadata.execution.markers
+        except AttributeError:
+            markers = []
+
+        if isinstance(markers, str):
+            markers = markers.split(",")
+
+        for marker in markers:
+            item.add_marker(marker)
+
+        yield item
 
 
 class NotebookFailedException(Exception):


### PR DESCRIPTION
Apologies for the unsolicited pull request. I've added a small bit of functionality to *nbmake* that we have found to be useful and thought others might as well.

This pull request allows users to mark notebooks in a way similar to what one might do with `@pytest.mark`. Markers are included within a notebook's metadata much like how the *allow_errors* and *timeout* options are specified. As an example,
```json
{
  "cells": [ ... ],
  "metadata": {
    "kernelspec": { ... },
    "execution": {
      "markers": ["slow"]
    }
  }
}
```
would mark this notebook as "slow".

Markers can be either an array of strings (i.e. `["slow", "memory_intensive"`) or a string of comma-separated markers (i.e. `"slow,memory_intensive"`). Notebooks can then be included or excluded in the tests through the `-m` option just as with other *pytest* tests (e.g. `pytest **/*.ipynb -m "slow and not memory_intensive"` would only run notebooks that are slow but not memory intensive).

If this is something you think could be a part of *nbmake* (great!), I can add some tests and write a bit of documentation to go with this. If not, no worries.