### PR TITLE
chore: run bump-pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ version = "v1.4.1"
 nbmake = "nbmake.pytest_plugin"
 
 [tool.poetry.dependencies]
-pydantic = "^1.7.2"
+pydantic = "^2.0.0"
 pytest = ">=6.1.0"
 python = "^3.7.0"
 nbclient = "^0.6.6"

--- a/src/nbmake/nb_result.py
+++ b/src/nbmake/nb_result.py
@@ -12,4 +12,4 @@ class NotebookError(BaseModel):
 
 class NotebookResult(BaseModel):
     nb: NotebookNode
-    error: Optional[NotebookError]
+    error: Optional[NotebookError] = None


### PR DESCRIPTION
Run the pydantic script `bump-pydantic` to allow the migration to pydantic 2.0.*