### PR TITLE
pytest_plugin.py: replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ nbclient = "^0.6.6"
 nbformat = "^5.0.8"
 Pygments = "^2.7.3"
 ipykernel = ">=5.4.0"
+importlib-metadata =  { version = "^6.8.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.0"

--- a/src/nbmake/pytest_plugin.py
+++ b/src/nbmake/pytest_plugin.py
@@ -3,7 +3,10 @@ import sys
 from pathlib import Path
 from typing import Any, Optional
 
-import pkg_resources
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
 
 from .pytest_items import NotebookFile
 
@@ -54,7 +57,7 @@ def pytest_collect_file(path: str, parent: Any) -> Optional[Any]:
     opt = parent.config.option
     p = Path(path)
     if opt.nbmake and p.match("*ipynb") and "_build" not in p.parts:
-        ver: int = int(pkg_resources.get_distribution("pytest").version[0])
+        ver: int = int(version("pytest")[0])
 
         if ver < 7:
             return NotebookFile.from_parent(parent, fspath=path)


### PR DESCRIPTION
This PR replaces the deprecated use of `pkg_resources`  with `importlib.metadata`.

 As `importlib.metadata.version()` is only availeable for `python>=3.8` I add `importlib-metadata` as dependency for `python<3.8` (not sure if I have done this right).